### PR TITLE
Add support for oneOf and map objects

### DIFF
--- a/appengine/schemas/synthetic.bigquery.json
+++ b/appengine/schemas/synthetic.bigquery.json
@@ -1,0 +1,148 @@
+{
+  "fields": [
+    {
+      "type": "STRING", 
+      "mode": "NULLABLE", 
+      "name": "clientId"
+    }, 
+    {
+      "fields": [
+        {
+          "fields": [
+            {
+              "type": "STRING", 
+              "mode": "NULLABLE", 
+              "name": "creationDate"
+            }
+          ], 
+          "type": "RECORD", 
+          "mode": "NULLABLE", 
+          "name": "profile"
+        }, 
+        {
+          "fields": [
+            {
+              "fields": [
+                {
+                  "type": "STRING", 
+                  "mode": "NULLABLE", 
+                  "name": "channel"
+                }
+              ], 
+              "type": "RECORD", 
+              "mode": "NULLABLE", 
+              "name": "update"
+            }
+          ], 
+          "type": "RECORD", 
+          "mode": "NULLABLE", 
+          "name": "settings"
+        }
+      ], 
+      "type": "RECORD", 
+      "mode": "NULLABLE", 
+      "name": "environment"
+    }, 
+    {
+      "type": "STRING", 
+      "mode": "NULLABLE", 
+      "name": "id"
+    }, 
+    {
+      "fields": [
+        {
+          "fields": [
+            {
+              "type": "STRING", 
+              "name": "key", 
+              "mode": "REQUIRED"
+            }, 
+            {
+              "fields": [
+                {
+                  "type": "INTEGER", 
+                  "name": "bucket_count", 
+                  "mode": "NULLABLE"
+                }, 
+                {
+                  "type": "INTEGER", 
+                  "name": "histogram_type", 
+                  "mode": "NULLABLE"
+                }, 
+                {
+                  "type": "INTEGER", 
+                  "name": "range", 
+                  "mode": "REPEATED"
+                }, 
+                {
+                  "type": "INTEGER", 
+                  "name": "sum", 
+                  "mode": "NULLABLE"
+                }, 
+                {
+                  "fields": [
+                    {
+                      "type": "STRING", 
+                      "name": "key", 
+                      "mode": "REQUIRED"
+                    }, 
+                    {
+                      "type": "INTEGER", 
+                      "name": "value", 
+                      "mode": "REQUIRED"
+                    }
+                  ], 
+                  "type": "RECORD", 
+                  "name": "values", 
+                  "mode": "REPEATED"
+                }
+              ], 
+              "type": "RECORD", 
+              "mode": "REQUIRED", 
+              "name": "value"
+            }
+          ], 
+          "type": "RECORD", 
+          "mode": "REPEATED", 
+          "name": "histograms"
+        }, 
+        {
+          "fields": [
+            {
+              "fields": [
+                {
+                  "fields": [
+                    {
+                      "type": "STRING", 
+                      "name": "key", 
+                      "mode": "REQUIRED"
+                    }, 
+                    {
+                      "type": "STRING", 
+                      "mode": "REQUIRED", 
+                      "name": "value"
+                    }
+                  ], 
+                  "type": "RECORD", 
+                  "mode": "REPEATED", 
+                  "name": "scalars"
+                }
+              ], 
+              "type": "RECORD", 
+              "mode": "NULLABLE", 
+              "name": "parent"
+            }
+          ], 
+          "type": "RECORD", 
+          "mode": "NULLABLE", 
+          "name": "processes"
+        }
+      ], 
+      "type": "RECORD", 
+      "mode": "NULLABLE", 
+      "name": "payload"
+    }
+  ], 
+  "type": "RECORD", 
+  "mode": "REQUIRED"
+}

--- a/appengine/schemas/synthetic.schema.json
+++ b/appengine/schemas/synthetic.schema.json
@@ -1,0 +1,100 @@
+{
+  "properties": {
+    "clientId": {
+      "type": "string"
+    },
+    "environment": {
+      "properties": {
+        "profile": {
+          "properties": {
+            "creationDate": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "settings": {
+          "properties": {
+            "update": {
+              "properties": {
+                "channel": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "id": {
+      "type": "string"
+    },
+    "payload": {
+      "properties": {
+        "histograms": {
+          "additionalProperties": {
+            "additionalProperties": false,
+            "properties": {
+              "bucket_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "histogram_type": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "range": {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              "sum": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "values": {
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^\\d+$": {
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "type": "object"
+        },
+        "info": {},
+        "processes": {
+          "properties": {
+            "parent": {
+              "properties": {
+                "scalars": {
+                  "additionalProperties": {
+                    "type": [
+                      "integer",
+                      "string",
+                      "boolean"
+                    ]
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/dataflow/src/main/resources/schemas/synthetic.bigquery.json
+++ b/dataflow/src/main/resources/schemas/synthetic.bigquery.json
@@ -1,0 +1,148 @@
+{
+  "fields": [
+    {
+      "type": "STRING", 
+      "mode": "NULLABLE", 
+      "name": "clientId"
+    }, 
+    {
+      "fields": [
+        {
+          "fields": [
+            {
+              "type": "STRING", 
+              "mode": "NULLABLE", 
+              "name": "creationDate"
+            }
+          ], 
+          "type": "RECORD", 
+          "mode": "NULLABLE", 
+          "name": "profile"
+        }, 
+        {
+          "fields": [
+            {
+              "fields": [
+                {
+                  "type": "STRING", 
+                  "mode": "NULLABLE", 
+                  "name": "channel"
+                }
+              ], 
+              "type": "RECORD", 
+              "mode": "NULLABLE", 
+              "name": "update"
+            }
+          ], 
+          "type": "RECORD", 
+          "mode": "NULLABLE", 
+          "name": "settings"
+        }
+      ], 
+      "type": "RECORD", 
+      "mode": "NULLABLE", 
+      "name": "environment"
+    }, 
+    {
+      "type": "STRING", 
+      "mode": "NULLABLE", 
+      "name": "id"
+    }, 
+    {
+      "fields": [
+        {
+          "fields": [
+            {
+              "type": "STRING", 
+              "name": "key", 
+              "mode": "REQUIRED"
+            }, 
+            {
+              "fields": [
+                {
+                  "type": "INTEGER", 
+                  "name": "bucket_count", 
+                  "mode": "NULLABLE"
+                }, 
+                {
+                  "type": "INTEGER", 
+                  "name": "histogram_type", 
+                  "mode": "NULLABLE"
+                }, 
+                {
+                  "type": "INTEGER", 
+                  "name": "range", 
+                  "mode": "REPEATED"
+                }, 
+                {
+                  "type": "INTEGER", 
+                  "name": "sum", 
+                  "mode": "NULLABLE"
+                }, 
+                {
+                  "fields": [
+                    {
+                      "type": "STRING", 
+                      "name": "key", 
+                      "mode": "REQUIRED"
+                    }, 
+                    {
+                      "type": "INTEGER", 
+                      "name": "value", 
+                      "mode": "REQUIRED"
+                    }
+                  ], 
+                  "type": "RECORD", 
+                  "name": "values", 
+                  "mode": "REPEATED"
+                }
+              ], 
+              "type": "RECORD", 
+              "mode": "REQUIRED", 
+              "name": "value"
+            }
+          ], 
+          "type": "RECORD", 
+          "mode": "REPEATED", 
+          "name": "histograms"
+        }, 
+        {
+          "fields": [
+            {
+              "fields": [
+                {
+                  "fields": [
+                    {
+                      "type": "STRING", 
+                      "name": "key", 
+                      "mode": "REQUIRED"
+                    }, 
+                    {
+                      "type": "STRING", 
+                      "mode": "REQUIRED", 
+                      "name": "value"
+                    }
+                  ], 
+                  "type": "RECORD", 
+                  "mode": "REPEATED", 
+                  "name": "scalars"
+                }
+              ], 
+              "type": "RECORD", 
+              "mode": "NULLABLE", 
+              "name": "parent"
+            }
+          ], 
+          "type": "RECORD", 
+          "mode": "NULLABLE", 
+          "name": "processes"
+        }
+      ], 
+      "type": "RECORD", 
+      "mode": "NULLABLE", 
+      "name": "payload"
+    }
+  ], 
+  "type": "RECORD", 
+  "mode": "REQUIRED"
+}

--- a/scripts/jsonschema_to_bigquery.py
+++ b/scripts/jsonschema_to_bigquery.py
@@ -146,7 +146,7 @@ def bq_schema(jschema):
 
             item = {
                 'type': 'RECORD',
-                'mode': 'REPEATING',
+                'mode': 'REPEATED',
                 'fields': [
                     {'name': 'key', 'type': 'STRING', 'mode': 'REQUIRED'},
                     value_schema
@@ -248,7 +248,7 @@ def bq_schema(jschema):
                     mode = 'REQUIRED'
 
                     is_consistent = all([dtype == state[TYPE][0] for dtype in state[TYPE]])
-                    is_repeating = [mode == 'REPEATING' for mode in state[MODE]]
+                    is_repeating = [mode == 'REPEATED' for mode in state[MODE]]
 
                     if not is_consistent or (any(is_repeating) and not all(is_repeating)):
                         # Remove this line for conflict resolution
@@ -265,7 +265,7 @@ def bq_schema(jschema):
                         dtype = state[TYPE][0]
 
                     if all(is_repeating):
-                        mode = "REPEATING"
+                        mode = "REPEATED"
                     elif any([mode == "NULLABLE" for mode in state[MODE]]):
                         mode = "NULLABLE"
 
@@ -511,7 +511,7 @@ class TestSchemaMap(unittest.TestCase):
             "additionalProperties": {"type": "integer"}
         }
         expected = {
-            'mode': 'REPEATING',
+            'mode': 'REPEATED',
             'type': 'RECORD',
             'fields': [
                 {'name': 'key', 'type': 'STRING', 'mode': 'REQUIRED'},
@@ -532,7 +532,7 @@ class TestSchemaMap(unittest.TestCase):
             }
         }
         expected = {
-            'mode': 'REPEATING',
+            'mode': 'REPEATED',
             'type': 'RECORD',
             'fields': [
                 {'name': 'key', 'type': 'STRING', 'mode': 'REQUIRED'},
@@ -558,7 +558,7 @@ class TestSchemaMap(unittest.TestCase):
             "additionalProperties": False
         }
         expected = {
-            'mode': 'REPEATING',
+            'mode': 'REPEATED',
             'type': 'RECORD',
             'fields': [
                 {'name': 'key', 'type': 'STRING', 'mode': 'REQUIRED'},
@@ -577,7 +577,7 @@ class TestSchemaMap(unittest.TestCase):
             "additionalProperties": {"type": "integer"}
         }
         expected = {
-            'mode': 'REPEATING',
+            'mode': 'REPEATED',
             'type': 'RECORD',
             'fields': [
                 {'name': 'key', 'type': 'STRING', 'mode': 'REQUIRED'},
@@ -597,7 +597,7 @@ class TestSchemaMap(unittest.TestCase):
             "additionalProperties": False
         }
         expected = {
-            'mode': 'REPEATING',
+            'mode': 'REPEATED',
             'type': 'RECORD',
             'fields': [
                 {'name': 'key', 'type': 'STRING', 'mode': 'REQUIRED'},
@@ -615,7 +615,7 @@ class TestSchemaMap(unittest.TestCase):
             "additionalProperties": {"type": "integer"}
         }
         expected = {
-            'mode': 'REPEATING',
+            'mode': 'REPEATED',
             'type': 'RECORD',
             'fields': [
                 {'name': 'key', 'type': 'STRING', 'mode': 'REQUIRED'},

--- a/scripts/jsonschema_to_bigquery.py
+++ b/scripts/jsonschema_to_bigquery.py
@@ -1,9 +1,30 @@
 #!/usr/bin/env python
 
 import json
-from sys import argv
-from sys import stderr
-from sys import stdin
+import unittest
+from sys import argv, stderr, stdin
+
+
+def main():
+    usage = 'usage: jsonschema_to_bigquery.py [<time_partitioning_field> <time_partitioning_type>] < jsonschema.json > bigqueryschema.json\n'
+
+    if len(argv) not in [1, 3]:
+        stderr.write(usage)
+        exit(1)
+
+    try:
+        jsonschema = json.loads(stdin.read())
+    except Exception:
+        stderr.write(usage)
+        exit(1)
+
+    schema = bq_schema(jsonschema)
+
+    if len(argv) == 3:
+        schema['fields'].append({'mode': 'REQUIRED', 'name': argv[1], 'type': argv[2]})
+
+    print(json.dumps(schema, indent=2))
+
 
 type_map = {
     'string': 'STRING',
@@ -110,22 +131,6 @@ def bq_schema(jschema):
         raise Exception(json.dumps([item,jschema, type(item['type']) in [str, unicode], type(item['type']) in [str, unicode] and item['type'] in type_map]))
     return item
 
-usage = 'usage: jsonschema_to_bigquery.py [<time_partitioning_field> <time_partitioning_type>] < jsonschema.json > bigqueryschema.json\n'
 
-if len(argv) not in [1, 3]:
-    stderr.write(usage)
-    exit(1)
-
-try:
-    jsonschema = json.loads(stdin.read())
-except Exception:
-    stderr.write(usage)
-    exit(1)
-
-schema = bq_schema(jsonschema)
-
-if len(argv) == 3:
-    schema['fields'].append({'mode': 'REQUIRED', 'name': argv[1], 'type': argv[2]})
-
-print(json.dumps(schema, indent=2))
-
+if __name__ == '__main__':
+    main()

--- a/scripts/jsonschema_to_bigquery.py
+++ b/scripts/jsonschema_to_bigquery.py
@@ -100,7 +100,7 @@ def bq_schema(jschema):
         if len(dtypes) == 1:
             dtype = dtypes.pop()
         else:
-            print("Incompatible multitypes, treating as a json blob")
+            # print("Incompatible multitypes, treating as a json blob")
             dtype = "string"
 
     if type(dtype) in [str, unicode] and dtype in type_map:
@@ -298,7 +298,8 @@ def bq_schema(jschema):
 
                 return root
         else:
-            print("oneOf types are incompatible, treating as a json blob")
+            # print("oneOf types are incompatible, treating as a json blob")
+            pass
 
     else:
         raise Exception(json.dumps([item, jschema, type(item['type']) in [str, unicode], type(item['type']) in [str, unicode] and item['type'] in type_map]))


### PR DESCRIPTION
I added support for `oneOf` and `map` objects to the jsonschema to bigquery script. This is useful for handling the `payload.histograms` fields or any other field that is naturally represented as a map in json. I've successfully converted the schema for a fake main ping dataset, now I have to do some system testing. 

There's a fairly comprehensive unit test suite, but there might be some mistakes with respect with the mode being REQUIRED vs NULLABLE. I've tried to write the least amount of unit tests to cover the most edge cases. Currently the only test that isn't passing is the `allOf` test case, I decided to leave the behavior as is because it isn't in the current version of the main ping schema.